### PR TITLE
BugFix : city 이름으로 조회하는 내용을 region 이름으로 조회하는 내용으로 수정

### DIFF
--- a/src/main/java/com/catchbug/server/board/BoardController.java
+++ b/src/main/java/com/catchbug/server/board/BoardController.java
@@ -78,10 +78,10 @@ public class BoardController {
     }
 
     @GetMapping("/api/cities/count")
-    public ResponseEntity getCityCount(@RequestParam String cityName){
+    public ResponseEntity getCityCount(@RequestParam String regionName){
 
         List<DtoOfGetCityCount> dtoOfGetCityCountList =
-                boardService.getCityCount(cityName);
+                boardService.getCityCount(regionName);
 
         Response response = Response.builder()
                 .content(dtoOfGetCityCountList)

--- a/src/main/java/com/catchbug/server/board/BoardRepository.java
+++ b/src/main/java/com/catchbug/server/board/BoardRepository.java
@@ -38,7 +38,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "avg(b.latitude) as latitude, " +
             "avg(b.longitude) as longitude " +
             "from Board b " +
-            "where b.city = :cityName " +
+            "where b.region = :regionName " +
             "group by b.city")
-    List<DtoOfGetCityCount> getCityCount(@Param("cityName") String cityName);
+    List<DtoOfGetCityCount> getCityCount(@Param("regionName") String regionName);
 }

--- a/src/main/java/com/catchbug/server/board/BoardService.java
+++ b/src/main/java/com/catchbug/server/board/BoardService.java
@@ -132,10 +132,11 @@ public class BoardService {
 
     /**
      * City Depth 단위로 Count 를 조회하는 메서드
+     * @param regionName : 조회하려는 지역 이름
      * @return 조회 결과 Dto
      */
-    public List<DtoOfGetCityCount> getCityCount(String cityName){
-        List<DtoOfGetCityCount> dtoOfGetCityCountList = boardRepository.getCityCount(cityName);
+    public List<DtoOfGetCityCount> getCityCount(String regionName){
+        List<DtoOfGetCityCount> dtoOfGetCityCountList = boardRepository.getCityCount(regionName);
 
         return dtoOfGetCityCountList;
     }


### PR DESCRIPTION
# Summary
city 이름으로 조회하는 내용을 region 이름으로 조회하는 내용으로 수정

# 버그 내용
현재 city이름을 입력하고 city의 하위 내용을 조회하도록 되어있습니다.
region을 입력하고 하위 city들의 정보들을 조회해야하는 것이 정상 흐름입니다.
